### PR TITLE
fix return args type

### DIFF
--- a/src/App/ArgumentParser.hh
+++ b/src/App/ArgumentParser.hh
@@ -59,7 +59,7 @@ final class ArgumentParser implements ApplicationSpecDisplayable, Parser
         return $this;
     }
 
-    public function parse(Traversable<string> $input = []) : Traversable<string>
+    public function parse(Traversable<string> $input = []) : ImmVector<string>
     {
         $parser = new OptionParser($this->options);
         return $parser->parse($input);

--- a/src/Parser/OptionParser.hh
+++ b/src/Parser/OptionParser.hh
@@ -14,7 +14,6 @@ namespace HHPack\Getopt\Parser;
 use HHPack\Getopt\Spec\{ Option, OptionSet, OptionCollection, HelpDisplayable };
 use HHPack\Getopt\Argv\{ ArgumentsConsumer, ArgumentsExtractor };
 
-
 final class OptionParser implements Parser, HelpDisplayable
 {
 
@@ -24,7 +23,7 @@ final class OptionParser implements Parser, HelpDisplayable
     {
     }
 
-    public function parse(Traversable<string> $input = []) : Traversable<string>
+    public function parse(Traversable<string> $input = []) : ImmVector<string>
     {
         list($argv, $notFlags) = $this->prepareArgs($input);
 
@@ -48,7 +47,7 @@ final class OptionParser implements Parser, HelpDisplayable
             $option->consume($consumer);
         }
 
-        return $args;
+        return $args->immutable();
     }
 
     private function prepareArgs(Traversable<string> $argv = []) : (Traversable<string>, Traversable<string>)

--- a/src/Parser/Parser.hh
+++ b/src/Parser/Parser.hh
@@ -16,5 +16,5 @@ interface Parser
     /**
      * Parse command line arguments
      */
-    public function parse(Traversable<string> $input) : Traversable<string>;
+    public function parse(Traversable<string> $input) : ImmVector<string>;
 }


### PR DESCRIPTION
Changed the type of parser **parse() method** return type.

Traversable<string> -> ImmVector<string>